### PR TITLE
Update ChartPanManager-- default drag unconstrained

### DIFF
--- a/jfxutils/src/main/java/org/gillius/jfxutils/chart/ChartPanManager.java
+++ b/jfxutils/src/main/java/org/gillius/jfxutils/chart/ChartPanManager.java
@@ -136,12 +136,14 @@ public class ChartPanManager {
 		yAxis.setAnimated( false );
 		yAxis.setAutoRanging( false );
 
-		if ( chartInfo.getPlotArea().contains( lastX, lastY ) ) {
-			panMode = PanMode.Both;
-		} else if ( chartInfo.getXAxisArea().contains( lastX, lastY ) ) {
+		if ( chartInfo.getXAxisArea().contains( lastX, lastY ) ) {
 			panMode = PanMode.Horizontal;
 		} else if ( chartInfo.getYAxisArea().contains( lastX, lastY ) ) {
 			panMode = PanMode.Vertical;
+		} else {
+			// probably chartInfo.getPlotArea().contains( lastX, lastY ), 
+			// but not necessarily, e.g. in the corners/title/etc.
+			panMode = PanMode.Both;	
 		}
 
 		dragging = true;


### PR DESCRIPTION
The IF-ELSE fork dropped through in some cases-- like dragging near the title or corners, in which case it would not change the pan mode from the previous mode.  Now, if the drag wasn't in the x-axis or y-axis, it just defaults to unconstrained panning.